### PR TITLE
Updated to work with Macy's

### DIFF
--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -18,8 +18,9 @@ Ur.QuickLoaders['geocode'] = (function(){
     var s = document.createElement('script');
     s.type = "text/javascript";
     s.src = "http://maps.googleapis.com/maps/api/js?sensor=true&callback=UrGeocode";
-    x$('head').html('bottom', s);
+    document.body.appendChild(s);  
   }
+
   
   var geocoder;
   var geocodeObj;


### PR DESCRIPTION
Insert of google api loader is not working right when inserted into bottom of head. Inserting it in bottom of body instead.
