### PR TITLE
Adjusted carousel to use translate() instead of translate3d() for ios 6 devices.

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -131,7 +131,7 @@ Ur.WindowLoaders["carousel"] = (function() {
       var oldAndroid = /Android [12]/.test(navigator.userAgent);
       
       //3-22-13: Modified to include iOS 6.x devices
-      var ios6Device = /iPhone OS 6/.test(navigator.userAgent);
+      var ios6Device = /iP(hone|od) OS 6/.test(navigator.userAgent);
       if ((oldAndroid && $container.attr("data-ur-android3d")[0] != "enabled") || ios6Device ) {
         self.options.transform3d = false;
         var speed = parseFloat($container.attr("data-ur-speed"));


### PR DESCRIPTION
...devices.
