### PR TITLE
Download link needs to be fixed

### DIFF
--- a/download.html
+++ b/download.html
@@ -14,11 +14,11 @@ download_selected: selected
   <p>Right-click on the appropriate file from the choices below, save it, then add it to your project.</p>
   <p>(Remember that you will also need to include <a href="//jquery.com/" target="_blank">jQuery</a> version 1.9.1 or greater in any page where you will be using Uranium interactions.)</p>
   <div id="links">
-    <a href="http://d1topzp4nao5hp.cloudfront.net/uranium-upload/{{version}}/uranium.js" target="_blank">
+    <a href="http://downloads.moovweb.com/uranium/{{version}}/uranium.js" target="_blank">
       <h4 class="link-header">Uranium {{version}}</h4><p>Minified</p>
     </a>
 
-    <a href="http://d1topzp4nao5hp.cloudfront.net/uranium-upload/{{version}}/uranium-pretty.js" target="_blank">
+    <a href="http://downloads.moovweb.com/uranium/{{version}}/uranium-pretty.js" target="_blank">
       <h4 class="link-header">Uranium {{version}}</h4><p>Full Source</p>
     </a>
 

--- a/site/download.html
+++ b/site/download.html
@@ -45,11 +45,11 @@
   <p>Right-click on the appropriate file from the choices below, save it, then add it to your project.</p>
   <p>(Remember that you will also need to include <a href="//jquery.com/" target="_blank">jQuery</a> version 1.9.1 or greater in any page where you will be using Uranium interactions.)</p>
   <div id="links">
-    <a href="http://d1topzp4nao5hp.cloudfront.net/uranium-upload/1.0.136/uranium.js" target="_blank">
+    <a href="http://downloads.moovweb.com/uranium/1.0.136/uranium.js" target="_blank">
       <h4 class="link-header">Uranium 1.0.136</h4><p>Minified</p>
     </a>
 
-    <a href="http://d1topzp4nao5hp.cloudfront.net/uranium-upload/1.0.136/uranium-pretty.js" target="_blank">
+    <a href="http://downloads.moovweb.com/uranium/1.0.136/uranium-pretty.js" target="_blank">
       <h4 class="link-header">Uranium 1.0.136</h4><p>Full Source</p>
     </a>
 


### PR DESCRIPTION
Josh requested that the download link change to reflect the new nosaka-based download of Uranium.

Instead of being a cloundfront url, the download link is in the following style:
http://downloads.moovweb.com/uranium/1.0.136/uranium.js
